### PR TITLE
feat(workflows): Auto-generate sbom

### DIFF
--- a/actions/jar-to-docker-21/action.yaml
+++ b/actions/jar-to-docker-21/action.yaml
@@ -45,6 +45,5 @@ runs:
       with:
         team: teamsykmelding
         salsa: true
-        byosbom: dependency-graph-reports/deploy_app_to_dev_and_prod-build.json
         identity_provider: ${{ inputs.identity_provider }}
         project_id: ${{ inputs.project_id }}

--- a/actions/jar-to-docker/action.yaml
+++ b/actions/jar-to-docker/action.yaml
@@ -45,6 +45,5 @@ runs:
       with:
         team: teamsykmelding
         salsa: true
-        byosbom: dependency-graph-reports/deploy_app_to_dev_and_prod-build.json
         identity_provider: ${{ inputs.identity_provider }}
         project_id: ${{ inputs.project_id }}


### PR DESCRIPTION
Det er mulig å sende med egen sbom, men då må formatet vare CycloneDx, men github sitt eget format er ikke støttet i backend som paser disse sbom. Ved å fjerne input for egen sbom så vill det genereres en automagsik, men det kan då legges på lit tid på deploy beroende på størrelse på prosjekt.

for å generere denne sbom i rett format så kan man se i nais doc: https://docs.nais.io/security/salsa/?h=#known-limitations-and-alternatives